### PR TITLE
Revert "Fix for deleting objects: object path must be URL percent-enc…

### DIFF
--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -50,7 +50,7 @@ defmodule Waffle.Storage.Google.CloudStorage do
     Objects.storage_objects_delete(
       conn(),
       bucket(definition),
-      path_for(definition, version, meta) |> URI.encode_www_form()
+      path_for(definition, version, meta)
     )
   end
 


### PR DESCRIPTION
…oded."

This reverts commit 15950128b7dc32467d8e05cc9414404eff956145.


This is what is causing the deletes to break in mandark. I don't think the encoding is necessary. 
E.g. a filename in the db is `882aba4a-2a44-4ca5-8b50-eb3a66059eb719:12:28.449405.png` and when we call waffle.delete('882aba4a-2a44-4ca5-8b50-eb3a66059eb719:12:28.449405.png') it's encoding the filename to '882aba4a-2a44-4ca5-8b50-eb3a66059eb719%3A12%3A28.449405.png' which no longer matches what we're storing in gcp  - `882aba4a-2a44-4ca5-8b50-eb3a66059eb719:12:28.449405.png`. 

I think it was originally merged to fix some silent errors but with our new changes to waffle we can just deal with those if/when they come up since they're now logged. 



